### PR TITLE
Hantera passiva tasks i schemaläggaren

### DIFF
--- a/application/data/recipes/gräddtårta.json
+++ b/application/data/recipes/gräddtårta.json
@@ -34,6 +34,16 @@
       "resources": [{ "resourceId": "ugn", "amount": 1 }]
     },
     {
+      "id": "ugnVärms",
+      "name": "Varm ugnen",
+      "instructions": "Låt ugnen bli 175°C.",
+      "initalTask": false,
+      "passive": true,
+      "estimatedTime": 5,
+      "ingredients": [],
+      "resources": [{ "resourceId": "ugn", "amount": 1 }]
+    },
+    {
       "id": "förberedForm",
       "name": "Förbered formen",
       "instructions": "Smörj och bröa en form med löstagbar kant (ca 24cm i diameter)",
@@ -64,7 +74,7 @@
       "resources": []
     },
     {
-      "id": "blandaTort",
+      "id": "blandaTorrt",
       "name": "Torra ingredienser",
       "instructions": "Blanda ihop vetemjöl, potatismjöl och bakpulver.",
       "estimatedTime": 5,
@@ -314,8 +324,12 @@
       "dependsOn": ["sikta"]
     },
     {
+      "taskId": "ugnVärms",
+      "strongDependsOn": ["ugnPå"]
+    },
+    {
       "taskId": "inUgn",
-      "dependsOn": ["hällForm", "ugnPå"]
+      "dependsOn": ["hällForm", "ugnVärms"]
     },
     {
       "taskId": "gräddas",

--- a/application/data/recipes/ugnspannkaka.json
+++ b/application/data/recipes/ugnspannkaka.json
@@ -79,6 +79,15 @@
       "resources": [{ "resourceId": "ugn", "amount": 1 }]
     },
     {
+      "id": "ugnVarm",
+      "name": "Värm ugnen",
+      "instructions": "Låt ugnen bli 225°C.",
+      "passive": true,
+      "estimatedTime": 10,
+      "ingredients": [],
+      "resources": [{ "resourceId": "ugn", "amount": 1 }]
+    },
+    {
       "id": "bunkeBlanda",
       "name": "Blanda i bunke",
       "instructions": "Blanda mjöl, socker, salt i bunke.",
@@ -205,6 +214,10 @@
       "dependsOn": ["hällUppLingon"]
     },
     {
+      "taskId": "ugnVarm",
+      "dependsOn": ["ugnStart"]
+    },
+    {
       "taskId": "vispaBunke",
       "dependsOn": ["bunkeBlanda"]
     },
@@ -230,7 +243,7 @@
     },
     {
       "taskId": "smetUgn",
-      "dependsOn": ["hällSmet"]
+      "dependsOn": ["hällSmet", "ugnVarm"]
     },
     {
       "taskId": "grädda",

--- a/application/src/data/Recipe.tsx
+++ b/application/src/data/Recipe.tsx
@@ -35,6 +35,7 @@ export type Task = {
   id: string;
   name: string;
   instructions: string;
+  passive?: boolean;
   ingredients: IngredientUsage[];
   resources: ResourceUsage[];
   initialTask?: boolean;

--- a/application/src/scheduler/BasicScheduler.tsx
+++ b/application/src/scheduler/BasicScheduler.tsx
@@ -51,7 +51,6 @@ export function createBasicScheduler(recipe: Recipe,
     },
     addCook: function(cook: CookID){
       cooks.includes(cook) ? "" : cooks.push(cook)
-      let task = getNextTask(recipe, this.completedTasks, this.currentTasks)
       assignNewTask(cook, this)
 
     },

--- a/application/src/scheduler/Scheduler.tsx
+++ b/application/src/scheduler/Scheduler.tsx
@@ -13,6 +13,7 @@ export type TaskAssignedSubscriber = (
  * Enbart metoderna bör användas. Ändra inte i de övriga fälten
  */
 export interface Scheduler {
+  readonly extended: Map<TaskID, [number, number]>;
   readonly cooks: CookID[];
   readonly recipe: Recipe;
   readonly completedTasks: TaskID[];
@@ -57,7 +58,7 @@ export interface Scheduler {
   /**
    * Hämtar nuvarande tasks
    */
-  getTasks: () => Map<CookID, TaskID>
+  getTasks: () => Map<CookID, TaskID>;
 
   // Subscription listor med alla subsribe funktioner
   readonly passiveTaskSubscribers: PassiveTaskSubscriber[];

--- a/application/src/screens/Home.tsx
+++ b/application/src/screens/Home.tsx
@@ -6,7 +6,7 @@ import { RootStackParamList } from "../navigation";
 import { recipes } from "../data";
 
 // Exempelkod för att matlagnings skärmen skall fungera
-const example_recipe = recipes[1];
+const example_recipe = recipes[2];
 const example_users = [
   {
     id: "kalle",
@@ -20,7 +20,6 @@ const example_users = [
     color: "blue",
     icon: require("../../assets/image/icon.png"),
   },
-
 ];
 
 type HomeScreenNavigationProp = StackNavigationProp<RootStackParamList, "Home">;


### PR DESCRIPTION
Funkar med både köttbullereceptet och ugnspankakereceptet. Gräddtårtan är trasig (det var den innan detta PR:et). Att förlänga tiden på en task har implementerats men används inte eftersom vi inte har något sett att se passiva tasks i frontenden än.

För utveckling är passiva tasks snabbare än de kommer vara: 1 minut går nu på 1 sekund.

Inga tester finns heller för att jag inte vet hur man skulle kunna testa något som tar tid. Att lägga in `wait` i ett test känns lite konstigt.
