### PR TITLE
Ändra css lite, komprimera task-kort

### DIFF
--- a/application/src/components/TaskCard.tsx
+++ b/application/src/components/TaskCard.tsx
@@ -239,6 +239,9 @@ const styles = StyleSheet.create({
     padding: 10,
     marginBottom: 10,
     alignItems: "center",
+
+    // Förhindrar text från att komma utanför lådan
+    paddingRight: 30,
   },
   userName: {
     fontWeight: "bold",
@@ -260,6 +263,8 @@ const styles = StyleSheet.create({
     fontSize: 15,
   },
   bigText: {
+    paddingTop: 5,
+    lineHeight: 25,
     fontSize: 25,
     fontWeight: "600",
   },

--- a/application/src/screens/Cooking.tsx
+++ b/application/src/screens/Cooking.tsx
@@ -471,7 +471,7 @@ const styles = StyleSheet.create({
     width: "95%",
   },
   spacingWithNoContent: {
-    height: "12%",
+    height: "6%",
   },
   minimizedTasksFlatListContainer: {
     width: "95%",


### PR DESCRIPTION
Task-kortet och notifikationer för passiva tasks har flyttats upp, nu täcks inte "Klar"-knappen.
Så här ser det ut på min mobil:
<details>
  <summary>Kortet</summary>

  ![after](https://user-images.githubusercontent.com/16006944/113705549-d75bf980-96dd-11eb-9d59-800dd77a614b.png)

</details>

<details>
  <summary>Notifikationer</summary>

  ![after_2](https://user-images.githubusercontent.com/16006944/113705227-76342600-96dd-11eb-90b7-d51307569295.png)

</details>

En ändring är att när en passiv task håller på samtidigt som en annan passiv task är klar så är klockan delvis över en notifikation.

