### PR TITLE
Fixa priorityCook

### DIFF
--- a/application/src/scheduler/BasicScheduler.tsx
+++ b/application/src/scheduler/BasicScheduler.tsx
@@ -281,8 +281,10 @@ function prioritizeAndAssignTasks(scheduler: Scheduler, eligibleTasks: TaskID[],
 function assignGivenTasks(scheduler: Scheduler, tasksToAssign: TaskID[], priorityCook?: CookID) {
   let cooks = vacantCooks(scheduler);
   if (priorityCook) {
-    cooks = cooks.filter(c => c != priorityCook)
-    cooks.push(priorityCook)
+    if (cooks.includes(priorityCook)) {
+      cooks = cooks.filter(c => c != priorityCook)
+      cooks.push(priorityCook)
+    }
   }
 
   for (const task of tasksToAssign) {


### PR DESCRIPTION
Vi tänkte först att `assignGivenTasks` bara skulle kallas en gång varje gång någon blev klar med en en uppgift och antog därför att priorityCook alltid var ledig. Nu kallas den två gånger och priorityCook kan ha blivit tilldelad en uppgift. Att kolla om priorityCook är ledig är en lätt fix.