### PR TITLE
Spara scheduler i globalt context

### DIFF
--- a/application/App.tsx
+++ b/application/App.tsx
@@ -3,19 +3,24 @@
  * Försök att inte skriva kod i App som hade kunnat skrivas i src
  */
 import "react-native-gesture-handler";
-import React from "react";
+import React, { useState } from "react";
 import { SafeAreaProvider, SafeAreaView } from "react-native-safe-area-context";
 
 import { Navigator } from "./src/navigation";
 import { LogBox } from "react-native";
-
+import { schedulerContext } from "./src/screens/scheduler-context";
+import { Scheduler } from "./src/scheduler";
 //
 LogBox.ignoreLogs(["Setting a timer"]);
 
 export default function App() {
+
+  const [scheduler, setscheduler] = useState<Scheduler>();
   return (
-    <SafeAreaProvider>
-      <Navigator />
-    </SafeAreaProvider>
+    <schedulerContext.Provider value={{scheduler: scheduler, setScheduler: (newScheduler) => { setscheduler(newScheduler) }}}>
+      <SafeAreaProvider>
+        <Navigator />
+      </SafeAreaProvider>
+    </schedulerContext.Provider>
   );
 }

--- a/application/src/navigation/Navigator.tsx
+++ b/application/src/navigation/Navigator.tsx
@@ -19,8 +19,8 @@ export type RootStackParamList = {
   Home: undefined;
   RecipeLibrary: undefined;
   RecipeOverview: { recipe: Recipe };
-  Cooking: { recipe: Recipe; users: User[] /*initScheduler?: Scheduler */ };
-  SessionStart: { recipe: Recipe; users: User[]; initScheduler?: Boolean };
+  Cooking: { recipe: Recipe; users?: User[]};
+  SessionStart: { recipe?: Recipe; users?: User[]; scheduler?: Boolean; /*scheduler?: Scheduler*/};
   RecipeFinished: undefined;
   ChefManagement: { recipe?: Recipe; users: User[] };
 };

--- a/application/src/scheduler/BasicScheduler.tsx
+++ b/application/src/scheduler/BasicScheduler.tsx
@@ -41,6 +41,8 @@ export function createBasicScheduler(recipe: Recipe,
     currentTasks: new Map<CookID, TaskID>(),
     currentPassiveTasks: new Map<TaskID, {finish: Date, timeout: NodeJS.Timeout}>(),
     finishTask: function (task: TaskID, cook: CookID) {
+      console.log("GOT HERE");
+      console.log("subscr", this.subscribeTaskAssigned)
       this.completedTasks.push(task);
       this.currentTasks.delete(cook);
       if(isRecipeFinished(this)){
@@ -180,6 +182,7 @@ function getTask(recipe: Recipe, taskID: TaskID): Task{
  */
 function getSubscribeFunction<FunctionType>(subList: FunctionType[]) {
   const subscribe = (subscribedFunction: FunctionType) => {
+    console.log("functions", subList)
     const unsubscribe = () => {subList = subList.filter((value) => value !== subscribedFunction)};
     subList.push(subscribedFunction);
     return unsubscribe;
@@ -240,7 +243,8 @@ function assignTasks(scheduler: Scheduler, cook?: CookID) {
   let passiveTasks: TaskID[]
   let eligibleTasks: TaskID[][]
   [passiveTasks, eligibleTasks] = getEligibleTasks(scheduler);
-
+  
+  console.log("startOfAssign")
   // Starta alla passiva tasks som är möjliga
   for (const passiveTask of passiveTasks) {
     let real_task = getTask(scheduler.recipe, passiveTask);
@@ -252,6 +256,7 @@ function assignTasks(scheduler: Scheduler, cook?: CookID) {
   for (const tasks of eligibleTasks) {
     prioritizeAndAssignTasks(scheduler, tasks, cook)
   }
+  console.log("endOfAssign")
 
 
 
@@ -291,6 +296,7 @@ function assignGivenTasks(scheduler: Scheduler, tasksToAssign: TaskID[], priorit
     const cook = cooks.pop()
     if (cook) {
       scheduler.currentTasks.set(cook, task);
+      console.log(scheduler.taskAssignedSubscribers[0]);
       scheduler.taskAssignedSubscribers.forEach((fn) => fn(task, cook))
     } else {
       break

--- a/application/src/scheduler/Scheduler.tsx
+++ b/application/src/scheduler/Scheduler.tsx
@@ -40,7 +40,7 @@ export interface Scheduler {
   /**
    * Metod som kallas på när en task är tilldelad
    */
-  subscribeTaskAssigned: (f: TaskAssignedSubscriber) => () => void;
+  subscribeTaskAssigned: (aaa: TaskAssignedSubscriber | undefined) => void;
   /**
    * Metod som kallas på när ny passiv task är startad
    */
@@ -94,6 +94,6 @@ export interface Scheduler {
   passiveTaskStartedSubscribers: PassiveTaskStartedSubscriber[];
   passiveTaskFinishedSubscribers: PassiveTaskFinishedSubscriber[];
   passiveTaskCheckFinishedSubscribers: PassiveTaskCheckFinishedSubscriber[];
-  taskAssignedSubscribers: TaskAssignedSubscriber[];
+  taskAssignedSubscribers: TaskAssignedSubscriber | undefined;
   readonly recipeFinishedSubscribers: RecipeFinishedSubscriber[];
 }

--- a/application/src/scheduler/Scheduler.tsx
+++ b/application/src/scheduler/Scheduler.tsx
@@ -40,27 +40,28 @@ export interface Scheduler {
   /**
    * Metod som kallas på när en task är tilldelad
    */
-  subscribeTaskAssigned: (aaa: TaskAssignedSubscriber | undefined) => void;
+  subscribeTaskAssigned:   (f: TaskAssignedSubscriber) => void;
+  unsubscribeTaskAssigned: (f: TaskAssignedSubscriber) => void;
   /**
    * Metod som kallas på när ny passiv task är startad
    */
-  subscribePassiveTaskStarted: (f: PassiveTaskStartedSubscriber) => () => void;
+  subscribePassiveTaskStarted:   (f: PassiveTaskStartedSubscriber) => void;
+  unsubscribePassiveTaskStarted: (f: PassiveTaskStartedSubscriber) => void;
   /**
    * Metod som kallas på när en passiv task är avslutad
    */
-  subscribePassiveTaskFinished: (
-    f: PassiveTaskFinishedSubscriber
-  ) => () => void;
+  subscribePassiveTaskFinished:   (f: PassiveTaskFinishedSubscriber ) => void;
+  unsubscribePassiveTaskFinished: (f: PassiveTaskFinishedSubscriber) => void;
   /**
    * Metod som kallas för att kolla att det passiva tasket är helt avslutat av användaren
    */
-  subscribePassiveTaskCheckFinished: (
-    f: PassiveTaskCheckFinishedSubscriber
-  ) => () => void;
+  subscribePassiveTaskCheckFinished:   (f: PassiveTaskCheckFinishedSubscriber) => void;
+  unsubscribePassiveTaskCheckFinished: (f: PassiveTaskCheckFinishedSubscriber) => void;
   /**
    * Metod som kallas på när alla task är avklarade
    */
-  subscribeRecipeFinished: (f: RecipeFinishedSubscriber) => () => void;
+  subscribeRecipeFinished:   (f: RecipeFinishedSubscriber) => void;
+  unsubscribeRecipeFinished: (f: RecipeFinishedSubscriber) => void;
   /**
    * Utöker tiden på en pågående passiv task
    */
@@ -94,6 +95,6 @@ export interface Scheduler {
   passiveTaskStartedSubscribers: PassiveTaskStartedSubscriber[];
   passiveTaskFinishedSubscribers: PassiveTaskFinishedSubscriber[];
   passiveTaskCheckFinishedSubscribers: PassiveTaskCheckFinishedSubscriber[];
-  taskAssignedSubscribers: TaskAssignedSubscriber | undefined;
-  readonly recipeFinishedSubscribers: RecipeFinishedSubscriber[];
+  taskAssignedSubscribers: TaskAssignedSubscriber[];
+  recipeFinishedSubscribers: RecipeFinishedSubscriber[];
 }

--- a/application/src/screens/Cooking.tsx
+++ b/application/src/screens/Cooking.tsx
@@ -183,10 +183,11 @@ export function Cooking({ navigation, route }: Props) {
 
     return () => {
       console.log("UNSIBSCRIBING")
-      passiveTaskStartedUnsubscribe();
-      passiveTaskFinishedUnsubscribe();
-      passiveTaskCheckFinishedUnsubscribe();
-      recipeFinishedUnsubscribe();
+      ssss.unsubscribeTaskAssigned(taskAssignedSubscriber);
+      ssss.unsubscribePassiveTaskStarted(passiveTaskStartedSubscriber);
+      ssss.unsubscribePassiveTaskFinished(passiveTaskFinishedSubscriber);
+      ssss.unsubscribePassiveTaskCheckFinished(passiveTaskCheckFinishedSubscriber);
+      ssss.unsubscribeRecipeFinished(recipeFinishedSubscriber);
     };
   }, []);
 

--- a/application/src/screens/Cooking.tsx
+++ b/application/src/screens/Cooking.tsx
@@ -124,7 +124,6 @@ export function Cooking({ navigation, route }: Props) {
   const passiveTaskStartedSubscriber = (task: string, finish: Date) => {
     setPassiveTasks((tasks) => {
       tasks.set(task, finish);
-      updateEarliestTimer(tasks);
       return new Map(tasks);
     });
   };
@@ -132,7 +131,6 @@ export function Cooking({ navigation, route }: Props) {
   const passiveTaskFinishedSubscriber = (task: string) => {
     setPassiveTasks((tasks) => {
       tasks.delete(task);
-      updateEarliestTimer(tasks);
       return new Map(tasks);
     });
     setVisiblePassiveTasks((prevVisablePassiveTasks) =>
@@ -150,6 +148,10 @@ export function Cooking({ navigation, route }: Props) {
   };
 
   useEffect(() => {
+    updateEarliestTimer(passiveTasks);
+  }, [passiveTasks])
+
+  useEffect(() => {
     let userIds = users.map((u) => u.id);
     let ssss: Scheduler;
     if (scheduler) {
@@ -158,18 +160,10 @@ export function Cooking({ navigation, route }: Props) {
       ssss = createBasicScheduler(recipe, userIds);
     }
     ssss.subscribeTaskAssigned(taskAssignedSubscriber);
-    const passiveTaskStartedUnsubscribe = ssss.subscribePassiveTaskStarted(
-      passiveTaskStartedSubscriber
-    );
-    const passiveTaskFinishedUnsubscribe = ssss.subscribePassiveTaskFinished(
-      passiveTaskFinishedSubscriber
-    );
-    const passiveTaskCheckFinishedUnsubscribe = ssss.subscribePassiveTaskCheckFinished(
-      passiveTaskCheckFinishedSubscriber
-    );
-    const recipeFinishedUnsubscribe = ssss.subscribeRecipeFinished(
-      recipeFinishedSubscriber
-    );
+    ssss.subscribePassiveTaskStarted(passiveTaskStartedSubscriber);
+    ssss.subscribePassiveTaskFinished(passiveTaskFinishedSubscriber);
+    ssss.subscribePassiveTaskCheckFinished(passiveTaskCheckFinishedSubscriber);
+    ssss.subscribeRecipeFinished(recipeFinishedSubscriber);
     setAssignedTasks(ssss.getTasks());
 
     let _userNotifications = new Map<string, boolean>();
@@ -213,7 +207,6 @@ export function Cooking({ navigation, route }: Props) {
         if (vTask === pTask) {
           setPassiveTasksInModal((mTasks) => {
             mTasks.delete(vTask);
-            updateEarliestTimer(mTasks);
             return new Map(mTasks);
           });
         }

--- a/application/src/screens/Cooking.tsx
+++ b/application/src/screens/Cooking.tsx
@@ -157,9 +157,7 @@ export function Cooking({ navigation, route }: Props) {
     } else {
       ssss = createBasicScheduler(recipe, userIds);
     }
-    const taskAssignedUnsubscribe = ssss.subscribeTaskAssigned(
-      taskAssignedSubscriber
-    );
+    ssss.subscribeTaskAssigned(taskAssignedSubscriber);
     const passiveTaskStartedUnsubscribe = ssss.subscribePassiveTaskStarted(
       passiveTaskStartedSubscriber
     );
@@ -185,7 +183,6 @@ export function Cooking({ navigation, route }: Props) {
 
     return () => {
       console.log("UNSIBSCRIBING")
-      taskAssignedUnsubscribe();
       passiveTaskStartedUnsubscribe();
       passiveTaskFinishedUnsubscribe();
       passiveTaskCheckFinishedUnsubscribe();

--- a/application/src/screens/Cooking.tsx
+++ b/application/src/screens/Cooking.tsx
@@ -165,6 +165,7 @@ export function Cooking({ navigation, route }: Props) {
     ssss.subscribePassiveTaskCheckFinished(passiveTaskCheckFinishedSubscriber);
     ssss.subscribeRecipeFinished(recipeFinishedSubscriber);
     setAssignedTasks(ssss.getTasks());
+    setPassiveTasks(ssss.getPassiveTasks());
 
     let _userNotifications = new Map<string, boolean>();
     ssss

--- a/application/src/screens/SessionStart.tsx
+++ b/application/src/screens/SessionStart.tsx
@@ -191,7 +191,7 @@ export function SessionStart({ navigation, route }: Props) {
           source={require("../../assets/image/play-button.png")} //TODO: chef.image
           // check chef.color to decide color of border
         />
-        <Text style={{color: "white", fontSize: 32}}>{recipeActivated ? "Börja om" : "Starta"}</Text>
+        <Text style={{color: "white", fontSize: 32}}>{recipeActivated ? "Fortsätt" : "Starta"}</Text>
       </Pressable>
       </View>
 

--- a/application/src/screens/scheduler-context.tsx
+++ b/application/src/screens/scheduler-context.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Scheduler } from "../scheduler";
+
+type ContextProps = { 
+  scheduler: Scheduler | undefined,
+  setScheduler: (a: Scheduler) => void,
+};
+
+// Make sure the shape of the default value passed to
+// createContext matches the shape that the consumers expect!
+export const schedulerContext = React.createContext<ContextProps>({
+  scheduler: undefined,
+  setScheduler: (_) => {},});
+


### PR DESCRIPTION
Detta gör det möjligt att gå bort från Cooking-skärmen medan ett recept pågår och sedan återvända. Vi märkte också att hur man tog bort och lade till subscribers till schedulern inte funkade så vi ändrade det.